### PR TITLE
Use FRONTEND_URL instead of hardcoded email portal URL

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -35,7 +35,7 @@ def get_logo_url():
     return None
 
 
-def send_html_email(subject, recipients, message, title=None, template="email_default_template.html", sender=MAIL_DEFAULT_SENDER, link_url="https://portal.example.nl", link_title="LOGIN to TAK Portal"):
+def send_html_email(subject, recipients, message, title=None, template="email_default_template.html", sender=MAIL_DEFAULT_SENDER, link_url=FRONTEND_URL, link_title="LOGIN to TAK Portal"):
     # Skip if email is disabled
     if not MAIL_ENABLED:
         logging.info(f"Email disabled - skipping email to {recipients} with subject '{subject}'")


### PR DESCRIPTION
The email template currently uses a hardcoded default URL:

https://portal.example.nl

This causes installation-specific links to appear in emails unless every caller overrides the parameter.

This PR replaces the hardcoded value with the already existing FRONTEND_URL configuration variable imported from app.settings.

This keeps email links consistent with the configured frontend URL and avoids installation-specific code modifications.